### PR TITLE
거래내역 화면 및 조회 페이지 생성 

### DIFF
--- a/src/main/java/com/newdeal/ledger/transaction/controller/TransactionController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/controller/TransactionController.java
@@ -1,0 +1,38 @@
+package com.newdeal.ledger.transaction.controller;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.newdeal.ledger.transaction.dto.TransactionListDto;
+import com.newdeal.ledger.transaction.service.TransactionService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/transaction")
+@RequiredArgsConstructor
+public class TransactionController {
+	private final TransactionService transactionService;
+
+	@GetMapping
+	public String getTransactions(Model model) {
+		String tempEmail = "user1@example.com";
+		int tempYear = 2024;
+		int tempMonth = 7;
+
+		List<TransactionListDto> transactionListDtos = transactionService.selectAllByMonth(
+			tempEmail,
+			tempYear,
+			tempMonth
+		);
+
+		System.out.println("dd");
+		model.addAttribute("transactionDtos", transactionListDtos);
+
+		return "/transaction";
+	}
+}

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionDto.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionDto.java
@@ -1,0 +1,26 @@
+package com.newdeal.ledger.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class TransactionDto {
+	private int tno;
+	private String email;
+	private int cno;
+	private String type;
+	private String stype;
+	private int sno;
+	private String keyword;
+	private long samount;
+	private int installment;
+	private String imageUrl;
+	private String tsmemo;
+	private Timestamp time;
+	private Integer rtype;
+}

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionListDto.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionListDto.java
@@ -1,0 +1,24 @@
+package com.newdeal.ledger.transaction.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class TransactionListDto {
+	public Integer tno;
+	public LocalDate date;
+	public LocalTime time;
+	public String category;
+	public String subCategory;
+	public String keyword;
+	public String amount;
+	public String memo;
+	public String installment;
+	public String tags;
+}

--- a/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
@@ -1,0 +1,18 @@
+package com.newdeal.ledger.transaction.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.newdeal.ledger.transaction.dto.TransactionDto;
+import com.newdeal.ledger.transaction.dto.TransactionListDto;
+
+@Mapper
+public interface TransactionMapper {
+	List<TransactionListDto> findAllByMonth(
+		@Param("email") String email,
+		@Param("year") int year,
+		@Param("month") int month
+	);
+}

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
@@ -1,0 +1,10 @@
+package com.newdeal.ledger.transaction.service;
+
+import java.util.List;
+
+import com.newdeal.ledger.transaction.dto.TransactionListDto;
+
+public interface TransactionService {
+
+	List<TransactionListDto> selectAllByMonth(String email, int year, int month);
+}

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
@@ -1,0 +1,23 @@
+package com.newdeal.ledger.transaction.service;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Service;
+
+import com.newdeal.ledger.transaction.dto.TransactionDto;
+import com.newdeal.ledger.transaction.dto.TransactionListDto;
+import com.newdeal.ledger.transaction.mapper.TransactionMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionServiceImpl implements TransactionService {
+	private final TransactionMapper mapper;
+
+	@Override
+	public List<TransactionListDto> selectAllByMonth(String email, int year, int month) {
+		return mapper.findAllByMonth(email, year, month);
+	}
+}

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -35,13 +35,13 @@ VALUES ('Groceries', 'user1@example.com'),
 
 SET @cno_food = (SELECT cno
                  FROM category
-                 WHERE name = '식사');
+                 WHERE name = '일식');
 SET @cno_cafe = (SELECT cno
                  FROM category
-                 WHERE name = '카페/간식');
+                 WHERE name = '베이커리');
 SET @cno_income = (SELECT cno
                    FROM category
-                   WHERE name = '주수입');
+                   WHERE name = '기타' AND parent_cno = 24);
 
 -- 기존 프로시저 삭제
 DROP PROCEDURE IF EXISTS GenerateTransactions;
@@ -107,8 +107,9 @@ VALUES (v_email,
         1,
         NULL,
         CONCAT('Memo ', v_count),
-        TIMESTAMP(v_date, '12:00:00'),
-        1);
+--         TIMESTAMP(v_date, '12:00:00'),
+        TIMESTAMP(v_date, SEC_TO_TIME((v_count MOD 24) * 3600 + (v_count MOD 60) * 60)), 1);
+
 
 SET v_count = v_count + 1;
 END WHILE;

--- a/src/main/resources/db/migration/V2__create_primary_table.sql
+++ b/src/main/resources/db/migration/V2__create_primary_table.sql
@@ -72,7 +72,7 @@ CREATE TABLE `transaction`
     `sno`         int         NOT NULL,
     `keyword`     varchar(250) NULL,
     `samount`     bigint      NOT NULL DEFAULT 0 COMMENT '수입: +, 지출: - ',
-    `installment` int         NOT NULL DEFAULT 0 COMMENT '일시불:1, 할부 개월:2~10',
+    `installment` int         NOT NULL DEFAULT 1 COMMENT '일시불:1, 할부 개월:2~10',
     `imageUrl`    text NULL,
     `tsmemo`      text NULL,
     `time`        TimeStamp NULL,

--- a/src/main/resources/mybatis/mapper/transaction-mapper.xml
+++ b/src/main/resources/mybatis/mapper/transaction-mapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.newdeal.ledger.transaction.mapper.TransactionMapper">
+
+    <select id="findAllByMonth" parameterType="map" resultType="com.newdeal.ledger.transaction.dto.TransactionListDto">
+        SELECT
+            t.tno,
+            DATE (t.time) AS date,
+            TIME (t.time) AS time,
+            parent_c.name AS category,
+            c.name AS subCategory,
+            t.keyword AS keyword,
+            t.samount AS amount,
+            t.tsmemo as memo,
+            CASE WHEN t.installment != 1 THEN '할부' ELSE '' END AS installment,
+            GROUP_CONCAT(tg.name SEPARATOR ', ') AS tags
+        FROM
+            transaction t
+        JOIN
+            category c ON t.cno = c.cno
+        JOIN
+            category parent_c ON c.parent_cno = parent_c.cno
+        LEFT JOIN
+            transactiontag tstg ON t.tno = tstg.tsno
+        LEFT JOIN
+            tag tg ON tstg.tgno = tg.tno
+        WHERE
+            YEAR (t.time) = #{year}
+            AND MONTH (t.time) = #{month}
+            AND t.email = #{email}
+        GROUP BY
+        t.tno;
+    </select>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/views/transaction.jsp
+++ b/src/main/webapp/WEB-INF/views/transaction.jsp
@@ -1,0 +1,102 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+         pageEncoding="UTF-8" %>
+<%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <title>YOONICORN 가계부</title>
+</head>
+<!-- ♣♣♣ CSS ♣♣♣ -->
+<link href="../css/inquiry.css?ver=1" rel="stylesheet"/>
+<!-- ♣♣♣ font ♣♣♣ -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+<!-- JQuery 최신 -->
+<script src="http://code.jquery.com/jquery-latest.min.js"></script>
+
+<!--◁◀◁◀ Header ▶▷▶▷ -->
+<%@ include file="/WEB-INF/views/include/header.jsp" %>
+<!--◁◀◁◀ Header ▶▷▶▷ -->
+
+
+<body>
+<div class="board-title-container">
+    <div class="board-title-area">
+        <h1 class="board-title">거래 내역</h1>
+    </div>
+    <div class="board-container">
+        <div class="qna-board-list-area">
+            <table>
+                <thead>
+                <tr class="qna-board-list-head">
+                    <th class="qna-board-list-date">날짜</th>
+                    <th class="qna-board-list-time">시간</th>
+                    <th class="qna-board-list-category">카테고리</th>
+                    <th class="qna-board-list-subCategory">서브 카테고리</th>
+                    <th class="qna-board-list-keyword">키워드</th>
+                    <th class="qna-board-list-amount">금액</th>
+                    <th class="qna-board-list-memo">메모</th>
+                    <th class="qna-board-list-tags">태그</th>
+                    <th class="qna-board-list-installment">할부</th>
+                </tr>
+                </thead>
+                <tbody>
+                <c:forEach var="transaction" items="${transactionDtos}">
+                    <tr class="qna-board-list-body">
+                        <td class="qna-board-list-date">${transaction.date}</td>
+                        <td class="qna-board-list-time">${transaction.time}</td>
+                        <td class="qna-board-list-category">${transaction.category}</td>
+                        <td class="qna-board-list-subCategory">${transaction.subCategory}</td>
+                        <td class="qna-board-list-keyword">${transaction.keyword}</td>
+                        <td class="qna-board-list-amount">${transaction.amount}</td>
+                        <td class="qna-board-list-memo">${transaction.memo}</td>
+                        <td class="qna-board-list-tags">${transaction.tags}</td>
+                        <td class="qna-board-list-installment">${transaction.installment}</td>
+                    </tr>
+                </c:forEach>
+                </tbody>
+            </table>
+        </div>
+        <div class="pagination-area">
+            <ul id="pagination">
+                <!--첫번째 페이지-->
+                <li class="pagination-first-page"><a href="/inquiry?page=1">처음</a></li>
+
+                <!--이전 페이지-->
+                <c:if test="${map.page>=1 }">
+                    <a href="/inquiry?page=${map.page-1 }"><i class="fa fa-chevron-left" aria-hidden="true"></i></a></li>
+                </c:if>
+
+                <!--페이지 넘버링-->
+                <c:forEach var="i" begin="${map.startPageNum}" end="${map.endPageNum }" step="1">
+                    <c:if test="${map.page==i }">
+                        <li class="pagination-number">${i}</li>
+                    </c:if>
+                    <c:if test="${map.page!=i }">
+                        <li class="pagination-number"><a href="/inquiry?page=${i}">${i}</a></li>
+                    </c:if>
+                </c:forEach>
+                <!--페이지 넘버링-->
+
+                <!--다음 페이지-->
+                <c:if test="${map.page<map.maxPage }">
+                    <a href="/inquiry?page=${map.page+1 }"><i class="fa fa-chevron-right" aria-hidden="true"></i></a></li>
+                </c:if>
+                <c:if test="${map.page>=map.maxPage }">
+                    <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                </c:if>
+                <!-- 마지막 페이지 -->
+                <li class="pagination-last-page">
+                    <a href="/inquiry?page=${map.maxPage }">마지막</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+</body>
+
+
+</html>


### PR DESCRIPTION
## 📌 PR 설명
- 년월 단위의 거래내역 조회 기능 및 화면을 구현했습니다.
<img width="1164" alt="스크린샷 2024-07-13 오후 5 00 57" src="https://github.com/user-attachments/assets/4c5458e8-f26e-4894-9a1d-6598de57ea02">

## 🖋️ 주요 작업 
- DB 쿼리단에서 필요한 데이터를 모은뒤 DTO에 매핑하였습니다. (마이바티스를 쓰다보니 자연스럽게 DB단에서 로직을 처리하네요..)
- 거래 내역에서는 페이지네이션을 적용하지 않을 예정입니다. 이유는 기본 스크롤 기능이 적용되고 추후 월별 통계처리에 부적합할 것 같습니다.
  (조금 더 생각해보고 필요하다면 오프셋 기반 페이지네이션을 적용하겠습니다)

- 거래내역이 생성될 때는  서브 카태고리 식별자가 저장됩니다. 찾을때는 서브 카테고리 식별자의 부모 카테고리 식별자를 통해 불러옵니다.
- 할부는 1일 때 없음, 2 이상일 때  조회 정보에 표시됩니다.  
 

## 📢 기타 
- 없음
