### PR TITLE
거래내역 년월 필터링 기능 추가 및 데이터 전달형식 AJAX 로 변경

### DIFF
--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountDto.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountDto.java
@@ -1,5 +1,7 @@
 package com.newdeal.ledger.cardaccount.dto;
 
+import com.newdeal.ledger.cardaccount.dto.type.AccountType;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountRequest.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountRequest.java
@@ -1,5 +1,7 @@
 package com.newdeal.ledger.cardaccount.dto;
 
+import com.newdeal.ledger.cardaccount.dto.type.AccountType;
+
 import lombok.Data;
 
 public class AccountRequest {

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountType.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/AccountType.java
@@ -1,5 +1,0 @@
-package com.newdeal.ledger.cardaccount.dto;
-
-public enum AccountType {
-	MONEY, ACCOUNT
-}

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/CardDto.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/CardDto.java
@@ -1,5 +1,7 @@
 package com.newdeal.ledger.cardaccount.dto;
 
+import com.newdeal.ledger.cardaccount.dto.type.CardType;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/CardRequest.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/CardRequest.java
@@ -1,5 +1,7 @@
 package com.newdeal.ledger.cardaccount.dto;
 
+import com.newdeal.ledger.cardaccount.dto.type.CardType;
+
 import lombok.Data;
 
 public class CardRequest {

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/CardType.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/CardType.java
@@ -1,5 +1,0 @@
-package com.newdeal.ledger.cardaccount.dto;
-
-public enum CardType {
-	CREDIT, CHECK
-}

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/type/AccountType.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/type/AccountType.java
@@ -1,0 +1,5 @@
+package com.newdeal.ledger.cardaccount.dto.type;
+
+public enum AccountType {
+	MONEY, ACCOUNT
+}

--- a/src/main/java/com/newdeal/ledger/cardaccount/dto/type/CardType.java
+++ b/src/main/java/com/newdeal/ledger/cardaccount/dto/type/CardType.java
@@ -1,0 +1,5 @@
+package com.newdeal.ledger.cardaccount.dto.type;
+
+public enum CardType {
+	CREDIT, CHECK
+}

--- a/src/main/java/com/newdeal/ledger/categorytag/dto/CategoryDto.java
+++ b/src/main/java/com/newdeal/ledger/categorytag/dto/CategoryDto.java
@@ -1,5 +1,7 @@
 package com.newdeal.ledger.categorytag.dto;
 
+import com.newdeal.ledger.categorytag.dto.type.CategoryType;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/newdeal/ledger/categorytag/dto/type/CategoryType.java
+++ b/src/main/java/com/newdeal/ledger/categorytag/dto/type/CategoryType.java
@@ -1,4 +1,4 @@
-package com.newdeal.ledger.categorytag.dto;
+package com.newdeal.ledger.categorytag.dto.type;
 
 public enum CategoryType {
 	INCOME, EXPENSE;

--- a/src/main/java/com/newdeal/ledger/transaction/controller/TransactionRestController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/controller/TransactionRestController.java
@@ -31,6 +31,8 @@ public class TransactionRestController {
 
 	}
 
+
+
 	@GetMapping("/source")
 	@ResponseStatus(HttpStatus.OK)
 	public List<SourceDto> getSource() {
@@ -40,5 +42,8 @@ public class TransactionRestController {
 
 		return sourceDtos;
 	}
+
+
+
 
 }

--- a/src/main/java/com/newdeal/ledger/transaction/controller/TransactionRestController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/controller/TransactionRestController.java
@@ -7,10 +7,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.newdeal.ledger.transaction.dto.SourceDto;
+import com.newdeal.ledger.transaction.dto.TransactionListDto;
 import com.newdeal.ledger.transaction.dto.TransactionRequest;
 import com.newdeal.ledger.transaction.service.TransactionService;
 
@@ -31,19 +33,19 @@ public class TransactionRestController {
 
 	}
 
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public List<TransactionListDto> getTransactions(@RequestParam int year, @RequestParam int month) {
+		String tempEmail = "user1@example.com";
 
+		return transactionService.selectAllByMonth(tempEmail, year, month);
+	}
 
 	@GetMapping("/source")
 	@ResponseStatus(HttpStatus.OK)
 	public List<SourceDto> getSource() {
 		String tempEmail = "user1@example.com";
 		List<SourceDto> sourceDtos = transactionService.selectAllSourceByEmail(tempEmail);
-
-
 		return sourceDtos;
 	}
-
-
-
-
 }

--- a/src/main/java/com/newdeal/ledger/transaction/controller/TransactionViewController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/controller/TransactionViewController.java
@@ -1,14 +1,8 @@
 package com.newdeal.ledger.transaction.controller;
 
-import java.util.List;
-
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import com.newdeal.ledger.transaction.dto.TransactionListDto;
-import com.newdeal.ledger.transaction.service.TransactionService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,22 +10,9 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/view/transaction")
 @RequiredArgsConstructor
 public class TransactionViewController {
-	private final TransactionService transactionService;
 
 	@GetMapping
-	public String getTransactions(Model model) {
-		String tempEmail = "user1@example.com";
-		int tempYear = 2024;
-		int tempMonth = 7;
-
-		List<TransactionListDto> transactionListDtos = transactionService.selectAllByMonth(
-			tempEmail,
-			tempYear,
-			tempMonth
-		);
-
-		model.addAttribute("transactionDtos", transactionListDtos);
-
+	public String getTransactions() {
 		return "/transaction/transaction";
 	}
 }

--- a/src/main/java/com/newdeal/ledger/transaction/dto/SourceDto.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/SourceDto.java
@@ -1,5 +1,8 @@
 package com.newdeal.ledger.transaction.dto;
 
+import com.newdeal.ledger.transaction.dto.type.SourceType;
+import com.newdeal.ledger.transaction.dto.type.SubSourceType;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/newdeal/ledger/transaction/dto/SourceType.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/SourceType.java
@@ -1,5 +1,0 @@
-package com.newdeal.ledger.transaction.dto;
-
-public enum SourceType {
-	ACCOUNT, CARD;
-}

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionDto.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionDto.java
@@ -6,6 +6,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import com.newdeal.ledger.transaction.dto.type.RepeatType;
+import com.newdeal.ledger.transaction.dto.type.SourceType;
+import com.newdeal.ledger.transaction.dto.type.TransactionType;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Data

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionRequest.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionRequest.java
@@ -5,6 +5,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+import com.newdeal.ledger.transaction.dto.type.RepeatType;
+import com.newdeal.ledger.transaction.dto.type.SourceType;
+import com.newdeal.ledger.transaction.dto.type.TransactionType;
+
 import lombok.Data;
 
 public class TransactionRequest {

--- a/src/main/java/com/newdeal/ledger/transaction/dto/type/RepeatType.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/type/RepeatType.java
@@ -1,4 +1,4 @@
-package com.newdeal.ledger.transaction.dto;
+package com.newdeal.ledger.transaction.dto.type;
 
 public enum RepeatType {
 	MONTHLY, WEEKLY, NONE;

--- a/src/main/java/com/newdeal/ledger/transaction/dto/type/SourceType.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/type/SourceType.java
@@ -1,0 +1,5 @@
+package com.newdeal.ledger.transaction.dto.type;
+
+public enum SourceType {
+	ACCOUNT, CARD;
+}

--- a/src/main/java/com/newdeal/ledger/transaction/dto/type/SubSourceType.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/type/SubSourceType.java
@@ -1,4 +1,4 @@
-package com.newdeal.ledger.transaction.dto;
+package com.newdeal.ledger.transaction.dto.type;
 
 public enum SubSourceType {
 	MONEY, ACCOUNT, CREDIT, CHECK

--- a/src/main/java/com/newdeal/ledger/transaction/dto/type/TransactionType.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/type/TransactionType.java
@@ -1,4 +1,4 @@
-package com.newdeal.ledger.transaction.dto;
+package com.newdeal.ledger.transaction.dto.type;
 
 public enum TransactionType {
 	EXPENSE, INCOME;

--- a/src/main/webapp/WEB-INF/views/transaction/transaction.jsp
+++ b/src/main/webapp/WEB-INF/views/transaction/transaction.jsp
@@ -14,6 +14,68 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- JQuery 최신 -->
     <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+
+    <script>
+        $(document).ready(function () {
+            // Populate year-month select box
+            var today = new Date();
+            var year = today.getFullYear();
+            var month = today.getMonth() + 1;
+
+            for (var y = year; y >= year - 10; y--) {
+                for (var m = 12; m >= 1; m--) {
+                    var monthValue = (m < 10 ? '0' : '') + m;
+                    var option = new Option(y + '-' + monthValue, y + '-' + monthValue);
+                    $('#year-month-select').append($(option));
+                }
+            }
+
+            // Set default value to current year-month
+            $('#year-month-select').val(year + '-' + (month < 10 ? '0' : '') + month);
+
+            function loadTransactions(year, month) {
+                $.ajax({
+                    url: '/api/transaction',
+                    type: 'GET',
+                    data: {
+                        year: year,
+                        month: month
+                    },
+                    success: function (data) {
+                        var tbody = $('#transaction-table tbody');
+                        tbody.empty();
+                        data.forEach(function (transaction) {
+                            var row = '<tr class="qna-board-list-body">' +
+                                '<td class="qna-board-list-date">' + transaction.date + '</td>' +
+                                '<td class="qna-board-list-time">' + transaction.time + '</td>' +
+                                '<td class="qna-board-list-category">' + transaction.category + '</td>' +
+                                '<td class="qna-board-list-subCategory">' + transaction.subCategory + '</td>' +
+                                '<td class="qna-board-list-keyword">' + transaction.keyword + '</td>' +
+                                '<td class="qna-board-list-amount">' + transaction.amount + '</td>' +
+                                '<td class="qna-board-list-memo">' + transaction.memo + '</td>' +
+                                '<td class="qna-board-list-tags">' + transaction.tags + '</td>' +
+                                '<td class="qna-board-list-installment">' + transaction.installment + '</td>' +
+                                '</tr>';
+                            tbody.append(row);
+                        });
+                    },
+                    error: function (xhr, status, error) {
+                        alert("Error fetching transactions: " + error);
+                    }
+                });
+            }
+
+            $('#filter-button').click(function () {
+                var selectedDate = $('#year-month-select').val();
+                var [selectedYear, selectedMonth] = selectedDate.split('-');
+                loadTransactions(selectedYear, selectedMonth);
+            });
+
+            // Load transactions for the current year and month on page load
+            loadTransactions(year, month);
+        });
+    </script>
+
     <style>
         .main-content {
             margin-left: 180px; /* Adjust according to the width of the sidebar */
@@ -32,10 +94,17 @@
         <div class="board-title-area">
             <h1 class="board-title">거래 내역</h1>
         </div>
+
+        <!-- Year-Month Selection -->
+        <div class="date-filter-container">
+            <select id="year-month-select"></select>
+            <button id="filter-button">필터</button>
+        </div>
+
         <%@ include file="/WEB-INF/views/transaction/createTransactionModal.jsp" %>
         <div class="board-container">
             <div class="qna-board-list-area">
-                <table>
+                <table id="transaction-table">
                     <thead>
                     <tr class="qna-board-list-head">
                         <th class="qna-board-list-date">날짜</th>
@@ -50,19 +119,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <c:forEach var="transaction" items="${transactionDtos}">
-                        <tr class="qna-board-list-body">
-                            <td class="qna-board-list-date">${transaction.date}</td>
-                            <td class="qna-board-list-time">${transaction.time}</td>
-                            <td class="qna-board-list-category">${transaction.category}</td>
-                            <td class="qna-board-list-subCategory">${transaction.subCategory}</td>
-                            <td class="qna-board-list-keyword">${transaction.keyword}</td>
-                            <td class="qna-board-list-amount">${transaction.amount}</td>
-                            <td class="qna-board-list-memo">${transaction.memo}</td>
-                            <td class="qna-board-list-tags">${transaction.tags}</td>
-                            <td class="qna-board-list-installment">${transaction.installment}</td>
-                        </tr>
-                    </c:forEach>
+                    <!-- Dynamic content will be loaded here via AJAX -->
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
## 📌 PR 설명
- 거래내역 년월 필터링 기능을 추가했습니다. 
- 데이터 전달형식 AJAX 로 변경해서 jsp 의존성을 덜어 내었습니다.

<img width="881" alt="스크린샷 2024-07-16 오후 2 12 50" src="https://github.com/user-attachments/assets/0ed0a707-8970-4e8c-8e22-cf5b53d4fe2e">

<img width="881" alt="스크린샷 2024-07-16 오후 2 13 09" src="https://github.com/user-attachments/assets/0d4bac35-3374-461d-b880-9b275708da47">

## 🖋️ 주요 작업 
- 년월은 현재 년도의 12월까지, 이전 10년 까지의 년월로 처리했습니다.

## 📢 기타 
- 최신순 조회는 별도의 작업으로 빼서 작업하겠습니다.
