### PR TITLE
거래내역 월별 최신순 정렬 기능 추가

### DIFF
--- a/src/main/resources/mybatis/mapper/transaction-mapper.xml
+++ b/src/main/resources/mybatis/mapper/transaction-mapper.xml
@@ -102,7 +102,9 @@
         AND MONTH (t.time) = #{month}
         AND t.email = #{email}
         GROUP BY
-        t.tno;
+        t.tno
+        ORDER BY
+        t.time desc;
     </select>
 
     <select id="findTransactionById" parameterType="int" resultMap="TransactionResultMap">


### PR DESCRIPTION
## 📌 PR 설명
- 년월 단위의 거래 내역 중 최신순으로 보여지도록  했습니다.
<img width="1191" alt="스크린샷 2024-07-17 오후 2 40 00" src="https://github.com/user-attachments/assets/029bcc33-e37d-40fa-9328-929439bd5e26">


## 🖋️ 주요 작업 
- 조회 시 뒤에 시간순 내림차순 정렬만 했습니다!

## 📢 기타 
- pr 에서 추가된 코드가 단 세줄이네요!
