### PR TITLE
주간, 월간 반복 수입지출 기능 구현

### DIFF
--- a/src/main/java/com/newdeal/ledger/LedgerApplication.java
+++ b/src/main/java/com/newdeal/ledger/LedgerApplication.java
@@ -3,7 +3,9 @@ package com.newdeal.ledger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class LedgerApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/newdeal/ledger/transaction/api/TransactionRestController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/api/TransactionRestController.java
@@ -50,13 +50,13 @@ public class TransactionRestController {
 	@ResponseStatus(HttpStatus.OK)
 	public List<TransactionResponse.GetList> getTransactions(@RequestParam int year, @RequestParam int month) {
 		String tempEmail = "user1@example.com";
-
 		return transactionService.getTransactionsByMonth(tempEmail, year, month);
 	}
 
 	@GetMapping(value = "/{transactionId}")
 	@ResponseStatus(HttpStatus.OK)
 	public TransactionResponse.GetOne getTransactionById(@PathVariable Integer transactionId) {
+		transactionService.createRepeatTypeTransactions();
 		return transactionService.getTransactionById(transactionId);
 	}
 

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionTagDto.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionTagDto.java
@@ -1,0 +1,13 @@
+package com.newdeal.ledger.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class TransactionTagDto {
+	public Integer transactionId;
+	public Integer tagId;
+}

--- a/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
@@ -9,11 +9,14 @@ import com.newdeal.ledger.transaction.dto.SourceDto;
 import com.newdeal.ledger.transaction.dto.TransactionDto;
 import com.newdeal.ledger.transaction.dto.TransactionRequest;
 import com.newdeal.ledger.transaction.dto.TransactionResponse;
+import com.newdeal.ledger.transaction.dto.TransactionTagDto;
 
 @Mapper
 public interface TransactionMapper {
 
 	Integer createTransaction(@Param("email") String email, @Param("request") TransactionRequest.Create request);
+
+	Integer createTransactionByDto(@Param("transactionDto") TransactionDto transactionDto);
 
 	void updateTransactionById(
 		@Param("transactionId") Integer transactionId,
@@ -32,7 +35,7 @@ public interface TransactionMapper {
 
 	TransactionDto findTransactionDtoById(Integer transactionId);
 
-	List<SourceDto> findSourcesByEmail(String email);
+	List<TransactionDto> findRepeatTypeTransactionDto();
 
 	void createTransactionTag(
 		@Param("transactionId") Integer transactionId,
@@ -41,4 +44,7 @@ public interface TransactionMapper {
 
 	void deleteTransactionTagByTransactionId(Integer transactionId);
 
+	List<TransactionTagDto> findTransactionTagByTransactionId(Integer transactionId);
+
+	List<SourceDto> findSourcesByEmail(String email);
 }

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
@@ -20,4 +20,5 @@ public interface TransactionService {
 
 	List<SourceDto> getSourcesByEmail(String email);
 
+	void createRepeatTypeTransactions();
 }

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
@@ -2,9 +2,11 @@ package com.newdeal.ledger.transaction.service;
 
 import java.util.List;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.newdeal.ledger.transaction.dto.SourceDto;
+import com.newdeal.ledger.transaction.dto.TransactionDto;
 import com.newdeal.ledger.transaction.dto.TransactionRequest;
 import com.newdeal.ledger.transaction.dto.TransactionResponse;
 import com.newdeal.ledger.transaction.mapper.TransactionMapper;
@@ -50,6 +52,26 @@ public class TransactionServiceImpl implements TransactionService {
 	@Override
 	public List<SourceDto> getSourcesByEmail(String email) {
 		return mapper.findSourcesByEmail(email);
+	}
+
+	@Scheduled(cron = "0 10 1 * * ?")
+	public void createRepeatTypeTransactions() {
+		System.out.println("ddddd start");
+		List<TransactionDto> repeatTypeTransactionDtoList = mapper.findRepeatTypeTransactionDto();
+
+		for (TransactionDto repeatTypeTransactionDto : repeatTypeTransactionDtoList) {
+			Integer repeatTypeTransactionId = repeatTypeTransactionDto.getTransactionId();
+
+			List<Integer> tagList = mapper.findTransactionTagByTransactionId(repeatTypeTransactionId)
+				.stream()
+				.map(transactionTagDto -> transactionTagDto.getTagId())
+				.toList();
+
+			mapper.createTransactionByDto(repeatTypeTransactionDto);
+			Integer newTransactionId = repeatTypeTransactionDto.getTransactionId();
+
+			mapper.createTransactionTag(newTransactionId, tagList);
+		}
 	}
 
 }

--- a/src/main/resources/mybatis/mapper/transaction-mapper.xml
+++ b/src/main/resources/mybatis/mapper/transaction-mapper.xml
@@ -51,6 +51,31 @@
             );
     </insert>
 
+    <insert id="createTransactionByDto" parameterType="map" useGeneratedKeys="true"
+            keyProperty="transactionDto.transactionId">
+        INSERT INTO `transaction`
+        (
+            `email`, `cno`, `type`, `stype`, `sno`, `keyword`,
+            `samount`, `installment`, `imageUrl`, `tsmemo`,
+            `time`, `rtype`
+        )
+        VALUES
+            (
+                #{transactionDto.email},
+                #{transactionDto.subCategoryId},
+                #{transactionDto.transactionType},
+                #{transactionDto.sourceType},
+                #{transactionDto.sourceId},
+                #{transactionDto.keyword},
+                #{transactionDto.amount},
+                #{transactionDto.installment},
+                #{transactionDto.imageUrl},
+                #{transactionDto.memo},
+                #{transactionDto.time},
+                #{transactionDto.repeatType}
+            );
+    </insert>
+
     <update id="updateTransactionById" parameterType="map">
         UPDATE `transaction`
         SET
@@ -151,6 +176,49 @@
         WHERE tno = #{transactionId}
     </select>
 
+    <select id="findRepeatTypeTransactionDto" resultType="com.newdeal.ledger.transaction.dto.TransactionDto">
+        SELECT tno         AS transactionId,
+               email       AS email,
+               cno         AS subCategoryId,
+               type        AS transactionType,
+               stype       AS sourceType,
+               sno         AS sourceId,
+               keyword     AS keyword,
+               samount     AS amount,
+               installment AS installment,
+               imageUrl    AS imageUrl,
+               tsmemo      AS memo, time AS time, rtype AS repeatType
+        FROM `transaction`
+        WHERE
+            (`rtype` = 'WEEKLY'
+          AND DATE (`time`) = DATE_SUB(CURDATE()
+            , INTERVAL 1 WEEK))
+           OR
+            (`rtype` = 'MONTHLY'
+          AND DATE (`time`) = DATE_SUB(CURDATE()
+            , INTERVAL 1 MONTH));
+    </select>
+
+    <insert id="createTransactionTag" parameterType="map">
+        INSERT INTO `transactiontag` (tsno, tgno)
+        VALUES
+        <foreach collection="tagIdList" item="tagId" separator=",">
+            (#{transactionId}, #{tagId})
+        </foreach>
+    </insert>
+
+    <delete id="deleteTransactionTagByTransactionId" parameterType="int">
+        DELETE FROM `transactiontag`
+        WHERE `tsno` = #{transactionId}
+    </delete>
+
+    <select id="findTransactionTagByTransactionId"  resultType = "com.newdeal.ledger.transaction.dto.TransactionTagDto"  parameterType="int">
+        SELECT tsno AS transactionId,
+               tgno   AS tagId
+        FROM `transactiontag`
+        WHERE tsno = #{transactionId}
+    </select>
+
     <select id="findSourcesByEmail" parameterType="String" resultType="com.newdeal.ledger.transaction.dto.SourceDto">
         SELECT 'ACCOUNT' as sourceType,
                CASE type
@@ -172,18 +240,5 @@
         FROM card
         WHERE email = #{email}
     </select>
-
-    <insert id="createTransactionTag" parameterType="map">
-        INSERT INTO `transactiontag` (tsno, tgno)
-        VALUES
-        <foreach collection="tagIdList" item="tagId" separator=",">
-            (#{transactionId}, #{tagId})
-        </foreach>
-    </insert>
-
-    <delete id="deleteTransactionTagByTransactionId" parameterType="int">
-        DELETE FROM `transactiontag`
-        WHERE `tsno` = #{transactionId}
-    </delete>
 
 </mapper>


### PR DESCRIPTION
## 📌 PR 설명
- 스케줄러를 적용해서 주간, 월간 반복 수입지출 기능 구현했습니다.
<img width="1170" alt="스크린샷 2024-07-17 오후 9 14 50" src="https://github.com/user-attachments/assets/63775d46-01fb-459b-8043-4b268e14ca8f">

## 🖋️ 주요 작업 
- 스케줄러 작동하는 메서드에  현재 날짜를 기준으로 월간, 주간 반복타입을 가지고 해당 기간만큼  떨어져 있는 데이터를 조회한 뒤 새로운 데이터를 만들어서 저장하는 로직입니다.


## 📢 기타 
- 비동기 동기를 고민하다가 비동기를 사용할 이유가 없어 동기를 사용했습니다.
- 동적 쿼리 기능을 사용해 벌크 연산을 하고 싶었으나 거래내역 태그 연관관계 테이블 떄문에 단건처리를 수행했습니다.
  (벌크 연산시 새로 생성된 거래내역 아이디를 받아 올 수 없어요...) 
- 쿼리 로그가 필요할 것 같네용
