### PR TITLE
쿼리 로그 기능 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+    // Log4JDBC
+    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+
     // swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,7 +3,8 @@ spring:
     url: ${LOCAL_DB_URL}
     username: ${LOCAL_DB_USER}
     password: ${LOCAL_DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+#    com.mysql.cj.jdbc.Driver
 
   flyway:
     locations: classpath:db/migration, classpath:db/data

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="true">
+
+    <!-- Appenders -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %5p [%c] %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="console-infolog" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %5p %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <!-- Logger -->
+    <logger name="com.newdeal" level="DEBUG" appender-ref="console" />
+    <logger name="jdbc.sqlonly" level="INFO" appender-ref="console-infolog" />
+    <logger name="jdbc.resultsettable" level="INFO" appender-ref="console-infolog" />
+
+    <!-- Root Logger -->
+    <root level="off">
+        <appender-ref ref="console" />
+    </root>
+</configuration>


### PR DESCRIPTION
## 📌 PR 설명
- log4jdbc 라이브러리를 추가해 마이바티스 쿼리 실행시 쿼리와 데이터가 로그로 남도록 했습니다.
- 외부 의존이 싫었지만, 기존 logback 설정으로는 한계가있어서 적용했고, 비용을 고려해 개인 개발 환경인 local에만 적용했습니다.
- 참고한 자료링크를 첨부합니다.
- [참고자료1](https://joo0jae.tistory.com/373), [참고자료2](https://congsong.tistory.com/23)

## 🖋️ 주요 작업 
- 없음 

## 📢 기타 
- 로컬에서 실행시 ${LOCAL_DB_URL} 환경변수가 변경됩니다. 파란색 drag 한 부분 추가해주시면 됩니다. 
<img width="940" alt="스크린샷 2024-07-17 오후 10 07 36" src="https://github.com/user-attachments/assets/f1c0bba1-f86b-40d1-bb78-9f33fdda0ebd">
