### PR TITLE
거래내역 멀티필터 기능 적용

### DIFF
--- a/src/main/java/com/newdeal/ledger/transaction/api/TransactionRestController.java
+++ b/src/main/java/com/newdeal/ledger/transaction/api/TransactionRestController.java
@@ -36,13 +36,14 @@ public class TransactionRestController {
 
 	@PutMapping(value = "/{transactionId}")
 	@ResponseStatus(HttpStatus.OK)
-	public void updateTransactionById(@PathVariable Integer transactionId, @ModelAttribute TransactionRequest.Update request){
+	public void updateTransactionById(@PathVariable Integer transactionId,
+		@ModelAttribute TransactionRequest.Update request) {
 		transactionService.updateTransactionById(transactionId, request);
 	}
 
 	@DeleteMapping(value = "/{transactionId}")
 	@ResponseStatus(HttpStatus.OK)
-	public void removeTransactionById(@PathVariable Integer transactionId){
+	public void removeTransactionById(@PathVariable Integer transactionId) {
 		transactionService.removeTransactionById(transactionId);
 	}
 
@@ -51,6 +52,15 @@ public class TransactionRestController {
 	public List<TransactionResponse.GetList> getTransactions(@RequestParam int year, @RequestParam int month) {
 		String tempEmail = "user1@example.com";
 		return transactionService.getTransactionsByMonth(tempEmail, year, month);
+	}
+
+	@GetMapping("/search")
+	@ResponseStatus(HttpStatus.OK)
+	public List<TransactionResponse.GetList> getTransactionsByMultiFilter(
+		@ModelAttribute TransactionRequest.MultiFilter request
+	) {
+		String tempEmail = "user1@example.com";
+		return transactionService.getTransactionsByMultiFilter(tempEmail, request);
 	}
 
 	@GetMapping(value = "/{transactionId}")

--- a/src/main/java/com/newdeal/ledger/transaction/dto/TransactionRequest.java
+++ b/src/main/java/com/newdeal/ledger/transaction/dto/TransactionRequest.java
@@ -63,4 +63,17 @@ public class TransactionRequest {
 			return LocalDateTime.of(date, time);
 		}
 	}
+
+	@Data
+	public static class MultiFilter{
+		private int year;
+		private int month;
+		private List<Integer> subCategoryIds;
+		private List<Integer> tagIds;
+		private List<Integer> installment;
+		private List<RepeatType> repeatType;
+		private List<SourceType> sourceType;
+		private List<Integer> sourceIds;
+		private String keyword;
+	}
 }

--- a/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/newdeal/ledger/transaction/mapper/TransactionMapper.java
@@ -42,6 +42,11 @@ public interface TransactionMapper {
 		@Param("tagIdList") List<Integer> tagIdList
 	);
 
+	List<TransactionResponse.GetList> findTransactionsByMultiFilter(
+		@Param("email") String email,
+		@Param("request") TransactionRequest.MultiFilter request
+	);
+
 	void deleteTransactionTagByTransactionId(Integer transactionId);
 
 	List<TransactionTagDto> findTransactionTagByTransactionId(Integer transactionId);

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionService.java
@@ -18,7 +18,13 @@ public interface TransactionService {
 
 	TransactionResponse.GetOne getTransactionById(Integer transactionId);
 
+	List<TransactionResponse.GetList> getTransactionsByMultiFilter(
+		String email,
+		TransactionRequest.MultiFilter request
+	);
+
 	List<SourceDto> getSourcesByEmail(String email);
 
 	void createRepeatTypeTransactions();
+
 }

--- a/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/com/newdeal/ledger/transaction/service/TransactionServiceImpl.java
@@ -45,6 +45,14 @@ public class TransactionServiceImpl implements TransactionService {
 	}
 
 	@Override
+	public List<TransactionResponse.GetList> getTransactionsByMultiFilter(
+		String email,
+		TransactionRequest.MultiFilter request
+	) {
+		return  mapper.findTransactionsByMultiFilter(email, request);
+	}
+
+	@Override
 	public TransactionResponse.GetOne getTransactionById(Integer transactionId) {
 		return mapper.findTransactionById(transactionId);
 	}

--- a/src/main/resources/mybatis/mapper/transaction-mapper.xml
+++ b/src/main/resources/mybatis/mapper/transaction-mapper.xml
@@ -132,6 +132,83 @@
         t.time desc;
     </select>
 
+    <select id="findTransactionsByMultiFilter" parameterType="map" resultType="com.newdeal.ledger.transaction.dto.TransactionResponse$GetList">
+        SELECT
+        t.tno AS transactionId,
+        DATE (t.time) AS date,
+        TIME (t.time) AS time,
+        parent_c.name AS category,
+        c.name AS subCategory,
+        t.keyword AS keyword,
+        t.samount AS amount,
+        t.tsmemo as memo,
+        CASE WHEN t.installment != 1 THEN '할부' ELSE '' END AS installment,
+        GROUP_CONCAT(tg.name SEPARATOR ', ') AS tags
+        FROM
+        transaction t
+        JOIN
+        category c ON t.cno = c.cno
+        JOIN
+        category parent_c ON c.parent_cno = parent_c.cno
+        LEFT JOIN
+        transactiontag tstg ON t.tno = tstg.tsno
+        LEFT JOIN
+        tag tg ON tstg.tgno = tg.tno
+        WHERE
+        YEAR (t.time) = #{request.year}
+        AND MONTH (t.time) = #{request.month}
+        AND t.email = #{email}
+        <if test="request.subCategoryIds != null and !request.subCategoryIds.isEmpty()">
+            AND c.cno IN
+            <foreach item="subCategoryId" collection="request.subCategoryIds" open="(" separator="," close=")">
+                #{subCategoryId}
+            </foreach>
+        </if>
+        <if test="request.tagIds != null and !request.tagIds.isEmpty()">
+            AND t.tno IN (
+            SELECT tsno FROM transactiontag tstg
+            WHERE tstg.tgno IN
+            <foreach item="tagId" collection="request.tagIds" open="(" separator="," close=")">
+                #{tagId}
+            </foreach>
+            )
+        </if>
+        <if test="request.installment != null and !request.installment.isEmpty()">
+            AND t.installment IN
+            <foreach item="inst" collection="request.installment" open="(" separator="," close=")">
+                #{inst}
+            </foreach>
+        </if>
+        <if test="request.repeatType != null and !request.repeatType.isEmpty()">
+            AND t.rtype IN
+            <foreach item="rt" collection="request.repeatType" open="(" separator="," close=")">
+                #{rt}
+            </foreach>
+        </if>
+        <if test="request.sourceType != null and !request.sourceType.isEmpty()">
+            AND t.stype IN
+            <foreach item="st" collection="request.sourceType" open="(" separator="," close=")">
+                #{st}
+            </foreach>
+        </if>
+        <if test="request.sourceIds != null and !request.sourceIds.isEmpty()">
+            AND t.sno IN
+            <foreach item="sn" collection="request.sourceIds" open="(" separator="," close=")">
+                #{sn}
+            </foreach>
+        </if>
+        <if test="request.keyword != null and !request.keyword.isEmpty()">
+            AND t.keyword LIKE CONCAT('%', #{request.keyword}, '%')
+        </if>
+        GROUP BY
+        t.tno
+        ORDER BY
+        t.time desc;
+    </select>
+
+
+
+
     <select id="findTransactionById" parameterType="int" resultMap="TransactionResultMap">
         SELECT
             t.tno AS transactionId,


### PR DESCRIPTION
## 📌 PR 설명
- 마이바티스 동적쿼리를 사용해서 거래내역 멀티필터 기능을 구현했습니다.
- 쉬운 이해를 위해 벤치마킹 사진을 공유합니다.
<img width="964" alt="스크린샷 2024-07-18 오전 7 56 12" src="https://github.com/user-attachments/assets/f41c7e5e-2977-458e-9bc4-bae581270e0f">


## 🖋️ 주요 작업 
-  동적쿼리를 사용해서 거래내역 멀티필터 API 작성 

## 📢 기타 
- 화면을 만들 시간이 부족해 swagger에서 테스트하여 확인헀습니다.
- 이넘타입을 적용해서 사용가능한 필터값을 노출하도록 했습니다.

swagger 확인
<img width="947" alt="스크린샷 2024-07-18 오전 7 49 38" src="https://github.com/user-attachments/assets/a6d3275a-3859-483c-9859-94586c44a200">

실제 테스트 사례
<img width="720" alt="스크린샷 2024-07-18 오전 7 49 11" src="https://github.com/user-attachments/assets/3ea8f524-ba3d-485a-9dbf-3dc525c9bc94">

